### PR TITLE
Resolve custom linter plugins with relative paths

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -532,6 +532,10 @@ type Config struct {
 		PathPrefix          string `mapstructure:"path-prefix"`
 	}
 
+	// The path that our config is from. nil if we weren't provided with one
+	// and we didn't find one ourselves.
+	ConfigFilePath *string
+
 	LintersSettings LintersSettings `mapstructure:"linters-settings"`
 	Linters         Linters
 	Issues          Issues

--- a/pkg/config/reader.go
+++ b/pkg/config/reader.go
@@ -84,6 +84,9 @@ func (r *FileReader) parseConfig() error {
 		os.Exit(0)
 	}
 
+	// Remember where our config came from
+	r.cfg.ConfigFilePath = &usedConfigFile
+
 	return nil
 }
 

--- a/pkg/golinters/goanalysis/linter.go
+++ b/pkg/golinters/goanalysis/linter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"go/token"
 	"runtime"
 	"sort"
 	"strings"
@@ -219,21 +220,63 @@ func buildIssues(diags []Diagnostic, linterNameBuilder func(diag *Diagnostic) st
 	var issues []result.Issue
 	for i := range diags {
 		diag := &diags[i]
-		linterName := linterNameBuilder(diag)
-		var text string
-		if diag.Analyzer.Name == linterName {
-			text = diag.Message
-		} else {
-			text = fmt.Sprintf("%s: %s", diag.Analyzer.Name, diag.Message)
-		}
-		issues = append(issues, result.Issue{
-			FromLinter: linterName,
-			Text:       text,
-			Pos:        diag.Position,
-			Pkg:        diag.Pkg,
-		})
+		issues = append(issues, buildSingleIssue(diag, linterNameBuilder(diag)))
 	}
 	return issues
+}
+
+func buildSingleIssue(diag *Diagnostic, linterName string) result.Issue {
+	text := generateIssueText(diag, linterName)
+	issue := result.Issue{
+		FromLinter: linterName,
+		Text:       text,
+		Pos:        diag.Position,
+		Pkg:        diag.Pkg,
+	}
+
+	if len(diag.SuggestedFixes) > 0 {
+		// Don't really have a better way of picking a best fix right now
+		chosenFix := diag.SuggestedFixes[0]
+
+		// It could be confusing to return more than one issue per single diagnostic,
+		// but if we return a subset it might be a partial application of a fix. Don't
+		// apply a fix unless there is only one for now
+		if len(chosenFix.TextEdits) == 1 {
+			edit := chosenFix.TextEdits[0]
+
+			pos := diag.Pkg.Fset.Position(edit.Pos)
+			end := diag.Pkg.Fset.Position(edit.End)
+
+			newLines := strings.Split(string(edit.NewText), "\n")
+
+			// This only works if we're only replacing whole lines with brand new lines
+			if onlyReplacesWholeLines(pos, end, newLines) {
+
+				// both original and new content ends with newline, omit to avoid partial line replacement
+				newLines = newLines[:len(newLines)-1]
+
+				issue.Replacement = &result.Replacement{NewLines: newLines}
+				issue.LineRange = &result.Range{From: pos.Line, To: end.Line - 1}
+
+				return issue
+			}
+		}
+	}
+
+	return issue
+}
+
+func onlyReplacesWholeLines(oPos token.Position, oEnd token.Position, newLines []string) bool {
+	return oPos.Column == 1 && oEnd.Column == 1 &&
+		oPos.Line < oEnd.Line && // must be replacing at least one line
+		newLines[len(newLines)-1] == "" // edit.NewText ended with '\n'
+}
+
+func generateIssueText(diag *Diagnostic, linterName string) string {
+	if diag.Analyzer.Name == linterName {
+		return diag.Message
+	}
+	return fmt.Sprintf("%s: %s", diag.Analyzer.Name, diag.Message)
 }
 
 func (lnt *Linter) preRun(lintCtx *linter.Context) error {

--- a/pkg/golinters/goanalysis/linter_test.go
+++ b/pkg/golinters/goanalysis/linter_test.go
@@ -2,7 +2,12 @@ package goanalysis
 
 import (
 	"fmt"
+	"go/token"
+	"reflect"
 	"testing"
+
+	"github.com/golangci/golangci-lint/pkg/result"
+	"golang.org/x/tools/go/analysis"
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/tools/go/packages"
@@ -45,4 +50,235 @@ func TestParseError(t *testing.T) {
 		assert.Equal(t, "typecheck", i.FromLinter)
 		assert.Equal(t, "msg", i.Text)
 	}
+}
+
+func Test_buildIssues(t *testing.T) {
+	type args struct {
+		diags             []Diagnostic
+		linterNameBuilder func(diag *Diagnostic) string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []result.Issue
+	}{
+		{
+			name: "No Diagnostics",
+			args: args{
+				diags: []Diagnostic{},
+				linterNameBuilder: func(*Diagnostic) string {
+					return "some-linter"
+				},
+			},
+			want: []result.Issue(nil),
+		},
+		{
+			name: "Linter Name is Analyzer Name",
+			args: args{
+				diags: []Diagnostic{
+					{
+						Diagnostic: analysis.Diagnostic{
+							Message: "failure message",
+						},
+						Analyzer: &analysis.Analyzer{
+							Name: "some-linter",
+						},
+						Position: token.Position{},
+						Pkg:      nil,
+					},
+				},
+				linterNameBuilder: func(*Diagnostic) string {
+					return "some-linter"
+				},
+			},
+			want: []result.Issue{
+				{
+					FromLinter: "some-linter",
+					Text:       "failure message",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildIssues(tt.args.diags, tt.args.linterNameBuilder); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildIssues() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_buildSingleIssue(t *testing.T) {
+	type args struct {
+		diag       *Diagnostic
+		linterName string
+	}
+	fakePkg := packages.Package{
+		Fset: makeFakeFileSet(),
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantIssue result.Issue
+	}{
+		{
+			name: "Linter Name is Analyzer Name",
+			args: args{
+				diag: &Diagnostic{
+					Diagnostic: analysis.Diagnostic{
+						Message: "failure message",
+					},
+					Analyzer: &analysis.Analyzer{
+						Name: "some-linter",
+					},
+					Position: token.Position{},
+					Pkg:      nil,
+				},
+
+				linterName: "some-linter",
+			},
+			wantIssue: result.Issue{
+				FromLinter: "some-linter",
+				Text:       "failure message",
+			},
+		},
+		{
+			name: "Linter Name is NOT Analyzer Name",
+			args: args{
+				diag: &Diagnostic{
+					Diagnostic: analysis.Diagnostic{
+						Message: "failure message",
+					},
+					Analyzer: &analysis.Analyzer{
+						Name: "some-analyzer",
+					},
+					Position: token.Position{},
+					Pkg:      nil,
+				},
+				linterName: "some-linter",
+			},
+			wantIssue: result.Issue{
+				FromLinter: "some-linter",
+				Text:       "some-analyzer: failure message",
+			},
+		},
+		{
+			name: "Shows issue when suggested edits exist but has no TextEdits",
+			args: args{
+				diag: &Diagnostic{
+					Diagnostic: analysis.Diagnostic{
+						Message: "failure message",
+						SuggestedFixes: []analysis.SuggestedFix{
+							{
+								Message:   "fix something",
+								TextEdits: []analysis.TextEdit{},
+							},
+						},
+					},
+					Analyzer: &analysis.Analyzer{
+						Name: "some-analyzer",
+					},
+					Position: token.Position{},
+					Pkg:      nil,
+				},
+				linterName: "some-linter",
+			},
+			wantIssue: result.Issue{
+				FromLinter: "some-linter",
+				Text:       "some-analyzer: failure message",
+			},
+		},
+		{
+			name: "Replace Whole Line",
+			args: args{
+				diag: &Diagnostic{
+					Diagnostic: analysis.Diagnostic{
+						Message: "failure message",
+						SuggestedFixes: []analysis.SuggestedFix{
+							{
+								Message: "fix something",
+								TextEdits: []analysis.TextEdit{
+									{
+										Pos:     101,
+										End:     201,
+										NewText: []byte("// Some comment to fix\n"),
+									},
+								},
+							},
+						},
+					},
+					Analyzer: &analysis.Analyzer{
+						Name: "some-analyzer",
+					},
+					Position: token.Position{},
+					Pkg:      &fakePkg,
+				},
+				linterName: "some-linter",
+			},
+			wantIssue: result.Issue{
+				FromLinter: "some-linter",
+				Text:       "some-analyzer: failure message",
+				LineRange: &result.Range{
+					From: 2,
+					To:   2,
+				},
+				Replacement: &result.Replacement{
+					NeedOnlyDelete: false,
+					NewLines: []string{
+						"// Some comment to fix",
+					},
+				},
+				Pkg: &fakePkg,
+			},
+		},
+		{
+			name: "Excludes Replacement if TextEdit doesn't modify only whole lines",
+			args: args{
+				diag: &Diagnostic{
+					Diagnostic: analysis.Diagnostic{
+						Message: "failure message",
+						SuggestedFixes: []analysis.SuggestedFix{
+							{
+								Message: "fix something",
+								TextEdits: []analysis.TextEdit{
+									{
+										Pos:     101,
+										End:     151,
+										NewText: []byte("// Some comment to fix\n"),
+									},
+								},
+							},
+						},
+					},
+					Analyzer: &analysis.Analyzer{
+						Name: "some-analyzer",
+					},
+					Position: token.Position{},
+					Pkg:      &fakePkg,
+				},
+				linterName: "some-linter",
+			},
+			wantIssue: result.Issue{
+				FromLinter: "some-linter",
+				Text:       "some-analyzer: failure message",
+				Pkg:        &fakePkg,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotIssues := buildSingleIssue(tt.args.diag, tt.args.linterName); !reflect.DeepEqual(gotIssues, tt.wantIssue) {
+				t.Errorf("buildSingleIssue() = %v, want %v", gotIssues, tt.wantIssue)
+			}
+		})
+	}
+}
+
+func makeFakeFileSet() *token.FileSet {
+	fSet := token.NewFileSet()
+	file := fSet.AddFile("fake.go", 1, 1000)
+	for i := 100; i < 1000; i += 100 {
+		file.AddLine(i)
+	}
+	return fSet
 }


### PR DESCRIPTION
golangci-lint resolves custom linter plugins relative to the current working directory. This makes configuring these plugins difficult because you often want to commit the `.golangci.yml` file to version control, but team members might have checked out the repo to different locations. As a result, the config file cannot use absolute paths. 

This PR changes the custom linter resolution so that it always resolves using an absolute path. If the path in the config is relative, golangci-lint pre-pends the detected (or provided) configuration file to the linter path to ensure it can be found. 

This is a first cut, so please feel free to suggest other ways of solving this issue. 

Resolves: https://github.com/golangci/golangci-lint/issues/1085